### PR TITLE
New Resource: time_sleep

### DIFF
--- a/internal/tftime/provider.go
+++ b/internal/tftime/provider.go
@@ -9,6 +9,7 @@ func Provider() *schema.Provider {
 		ResourcesMap: map[string]*schema.Resource{
 			"time_offset":   resourceTimeOffset(),
 			"time_rotating": resourceTimeRotating(),
+			"time_sleep":    resourceTimeSleep(),
 			"time_static":   resourceTimeStatic(),
 		},
 	}

--- a/internal/tftime/provider_test.go
+++ b/internal/tftime/provider_test.go
@@ -36,6 +36,16 @@ func testCheckAttributeValuesDiffer(i *string, j *string) resource.TestCheckFunc
 	}
 }
 
+func testCheckAttributeValuesSame(i *string, j *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if testStringValue(i) != testStringValue(j) {
+			return fmt.Errorf("attribute values are different")
+		}
+
+		return nil
+	}
+}
+
 func testExtractResourceAttr(resourceName string, attributeName string, attributeValue *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]

--- a/internal/tftime/resource_time_sleep.go
+++ b/internal/tftime/resource_time_sleep.go
@@ -1,0 +1,94 @@
+package tftime
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceTimeSleep() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTimeSleepCreate,
+		Read:   schema.Noop,
+		Update: schema.Noop,
+		Delete: resourceTimeSleepDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+				idParts := strings.Split(d.Id(), ",")
+
+				if len(idParts) != 2 || (idParts[0] == "" && idParts[1] == "") {
+					return nil, fmt.Errorf("Unexpected format of ID (%q), expected CREATESECONDS,DESTROYSECONDS where at least one value is non-empty", d.Id())
+				}
+
+				createSeconds, _ := strconv.Atoi(idParts[0])
+				destroySeconds, _ := strconv.Atoi(idParts[1])
+
+				if createSeconds > 0 {
+					if err := d.Set("create_seconds", createSeconds); err != nil {
+						return nil, fmt.Errorf("error setting create_seconds: %s", err)
+					}
+				}
+
+				if destroySeconds > 0 {
+					if err := d.Set("destroy_seconds", destroySeconds); err != nil {
+						return nil, fmt.Errorf("error setting destroy_seconds: %s", err)
+					}
+				}
+
+				d.SetId(time.Now().UTC().Format(time.RFC3339))
+
+				return []*schema.ResourceData{d}, nil
+			},
+		},
+
+		Schema: map[string]*schema.Schema{
+			"create_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"create_seconds",
+					"destroy_seconds",
+				},
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"destroy_seconds": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				AtLeastOneOf: []string{
+					"create_seconds",
+					"destroy_seconds",
+				},
+				ValidateFunc: validation.IntAtLeast(1),
+			},
+			"triggers": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceTimeSleepCreate(d *schema.ResourceData, m interface{}) error {
+	if v, ok := d.GetOk("create_seconds"); ok {
+		time.Sleep(time.Duration(v.(int)) * time.Second)
+	}
+
+	d.SetId(time.Now().UTC().Format(time.RFC3339))
+
+	return nil
+}
+
+func resourceTimeSleepDelete(d *schema.ResourceData, m interface{}) error {
+	if v, ok := d.GetOk("destroy_seconds"); ok {
+		time.Sleep(time.Duration(v.(int)) * time.Second)
+	}
+
+	return nil
+}

--- a/internal/tftime/resource_time_sleep_test.go
+++ b/internal/tftime/resource_time_sleep_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccTimeSleep_CreateSeconds(t *testing.T) {
+func TestAccTimeSleep_CreateDuration(t *testing.T) {
 	var time1, time2 string
 	resourceName := "time_sleep.test"
 
@@ -17,9 +17,9 @@ func TestAccTimeSleep_CreateSeconds(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigTimeSleepCreateSeconds(1),
+				Config: testAccConfigTimeSleepCreateDuration("1ms"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "create_seconds", "1"),
+					resource.TestCheckResourceAttr(resourceName, "create_duration", "1ms"),
 					testExtractResourceAttr(resourceName, "id", &time1),
 				),
 			},
@@ -30,9 +30,9 @@ func TestAccTimeSleep_CreateSeconds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigTimeSleepCreateSeconds(2),
+				Config: testAccConfigTimeSleepCreateDuration("2ms"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "create_seconds", "2"),
+					resource.TestCheckResourceAttr(resourceName, "create_duration", "2ms"),
 					testExtractResourceAttr(resourceName, "id", &time2),
 					testCheckAttributeValuesSame(&time1, &time2),
 				),
@@ -41,7 +41,7 @@ func TestAccTimeSleep_CreateSeconds(t *testing.T) {
 	})
 }
 
-func TestAccTimeSleep_DestroySeconds(t *testing.T) {
+func TestAccTimeSleep_DestroyDuration(t *testing.T) {
 	var time1, time2 string
 	resourceName := "time_sleep.test"
 
@@ -50,9 +50,9 @@ func TestAccTimeSleep_DestroySeconds(t *testing.T) {
 		CheckDestroy: nil,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccConfigTimeSleepDestroySeconds(1),
+				Config: testAccConfigTimeSleepDestroyDuration("1ms"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "destroy_seconds", "1"),
+					resource.TestCheckResourceAttr(resourceName, "destroy_duration", "1ms"),
 					testExtractResourceAttr(resourceName, "id", &time1),
 				),
 			},
@@ -63,9 +63,9 @@ func TestAccTimeSleep_DestroySeconds(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccConfigTimeSleepDestroySeconds(2),
+				Config: testAccConfigTimeSleepDestroyDuration("2ms"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "destroy_seconds", "2"),
+					resource.TestCheckResourceAttr(resourceName, "destroy_duration", "2ms"),
 					testExtractResourceAttr(resourceName, "id", &time2),
 					testCheckAttributeValuesSame(&time1, &time2),
 				),
@@ -117,33 +117,33 @@ func testAccTimeSleepImportStateIdFunc(resourceName string) resource.ImportState
 			return "", fmt.Errorf("Not found: %s", resourceName)
 		}
 
-		createSeconds := rs.Primary.Attributes["create_seconds"]
-		destroySeconds := rs.Primary.Attributes["destroy_seconds"]
+		createDuration := rs.Primary.Attributes["create_duration"]
+		destroyDuration := rs.Primary.Attributes["destroy_duration"]
 
-		return fmt.Sprintf("%s,%s", createSeconds, destroySeconds), nil
+		return fmt.Sprintf("%s,%s", createDuration, destroyDuration), nil
 	}
 }
 
-func testAccConfigTimeSleepCreateSeconds(createSeconds int) string {
+func testAccConfigTimeSleepCreateDuration(createDuration string) string {
 	return fmt.Sprintf(`
 resource "time_sleep" "test" {
-  create_seconds = %[1]d
+  create_duration = %[1]q
 }
-`, createSeconds)
+`, createDuration)
 }
 
-func testAccConfigTimeSleepDestroySeconds(destroySeconds int) string {
+func testAccConfigTimeSleepDestroyDuration(destroyDuration string) string {
 	return fmt.Sprintf(`
 resource "time_sleep" "test" {
-  destroy_seconds = %[1]d
+  destroy_duration = %[1]q
 }
-`, destroySeconds)
+`, destroyDuration)
 }
 
 func testAccConfigTimeSleepTriggers1(keeperKey1 string, keeperKey2 string) string {
 	return fmt.Sprintf(`
 resource "time_sleep" "test" {
-  create_seconds = 1
+  create_duration = "1s"
 
   triggers = {
     %[1]q = %[2]q

--- a/internal/tftime/resource_time_sleep_test.go
+++ b/internal/tftime/resource_time_sleep_test.go
@@ -1,0 +1,153 @@
+package tftime
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccTimeSleep_CreateSeconds(t *testing.T) {
+	var time1, time2 string
+	resourceName := "time_sleep.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTimeSleepCreateSeconds(1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "create_seconds", "1"),
+					testExtractResourceAttr(resourceName, "id", &time1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccTimeSleepImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigTimeSleepCreateSeconds(2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "create_seconds", "2"),
+					testExtractResourceAttr(resourceName, "id", &time2),
+					testCheckAttributeValuesSame(&time1, &time2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTimeSleep_DestroySeconds(t *testing.T) {
+	var time1, time2 string
+	resourceName := "time_sleep.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTimeSleepDestroySeconds(1),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destroy_seconds", "1"),
+					testExtractResourceAttr(resourceName, "id", &time1),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateIdFunc: testAccTimeSleepImportStateIdFunc(resourceName),
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccConfigTimeSleepDestroySeconds(2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "destroy_seconds", "2"),
+					testExtractResourceAttr(resourceName, "id", &time2),
+					testCheckAttributeValuesSame(&time1, &time2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccTimeSleep_Triggers(t *testing.T) {
+	var time1, time2 string
+	resourceName := "time_sleep.test"
+
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: nil,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccConfigTimeSleepTriggers1("key1", "value1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "triggers.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "triggers.key1", "value1"),
+					testExtractResourceAttr(resourceName, "id", &time1),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateIdFunc:       testAccTimeSleepImportStateIdFunc(resourceName),
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"triggers"},
+			},
+			{
+				Config: testAccConfigTimeSleepTriggers1("key1", "value1updated"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "triggers.%", "1"),
+					resource.TestCheckResourceAttr(resourceName, "triggers.key1", "value1updated"),
+					testExtractResourceAttr(resourceName, "id", &time2),
+					testCheckAttributeValuesDiffer(&time1, &time2),
+				),
+			},
+		},
+	})
+}
+
+func testAccTimeSleepImportStateIdFunc(resourceName string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("Not found: %s", resourceName)
+		}
+
+		createSeconds := rs.Primary.Attributes["create_seconds"]
+		destroySeconds := rs.Primary.Attributes["destroy_seconds"]
+
+		return fmt.Sprintf("%s,%s", createSeconds, destroySeconds), nil
+	}
+}
+
+func testAccConfigTimeSleepCreateSeconds(createSeconds int) string {
+	return fmt.Sprintf(`
+resource "time_sleep" "test" {
+  create_seconds = %[1]d
+}
+`, createSeconds)
+}
+
+func testAccConfigTimeSleepDestroySeconds(destroySeconds int) string {
+	return fmt.Sprintf(`
+resource "time_sleep" "test" {
+  destroy_seconds = %[1]d
+}
+`, destroySeconds)
+}
+
+func testAccConfigTimeSleepTriggers1(keeperKey1 string, keeperKey2 string) string {
+	return fmt.Sprintf(`
+resource "time_sleep" "test" {
+  create_seconds = 1
+
+  triggers = {
+    %[1]q = %[2]q
+  }
+}
+`, keeperKey1, keeperKey2)
+}

--- a/internal/tftime/resource_time_sleep_test.go
+++ b/internal/tftime/resource_time_sleep_test.go
@@ -3,10 +3,61 @@ package tftime
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
+
+// Since the acceptance testing framework can introduce uncontrollable time delays,
+// verify that sleeping works as expected via unit testing.
+func TestResourceTimeSleepCreate(t *testing.T) {
+	durationStr := "1s"
+	expectedDuration, err := time.ParseDuration("1s")
+
+	if err != nil {
+		t.Fatalf("unable to parse test duration: %s", err)
+	}
+
+	d := resourceTimeSleep().Data(nil)
+	d.SetType("time_sleep")
+	d.SetId("test")
+	d.Set("create_duration", durationStr)
+
+	start := time.Now()
+	resourceTimeSleepCreate(d, nil)
+	end := time.Now()
+	elapsed := end.Sub(start)
+
+	if elapsed < expectedDuration {
+		t.Errorf("did not sleep long enough, expected duration: %d got: %d", expectedDuration, elapsed)
+	}
+}
+
+// Since the acceptance testing framework can introduce uncontrollable time delays,
+// verify that sleeping works as expected via unit testing.
+func TestResourceTimeSleepDelete(t *testing.T) {
+	durationStr := "1s"
+	expectedDuration, err := time.ParseDuration("1s")
+
+	if err != nil {
+		t.Fatalf("unable to parse test duration: %s", err)
+	}
+
+	d := resourceTimeSleep().Data(nil)
+	d.SetType("time_sleep")
+	d.SetId("test")
+	d.Set("destroy_duration", durationStr)
+
+	start := time.Now()
+	resourceTimeSleepDelete(d, nil)
+	end := time.Now()
+	elapsed := end.Sub(start)
+
+	if elapsed < expectedDuration {
+		t.Errorf("did not sleep long enough, expected duration: %d got: %d", expectedDuration, elapsed)
+	}
+}
 
 func TestAccTimeSleep_CreateDuration(t *testing.T) {
 	var time1, time2 string

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -13,9 +13,13 @@ Use the navigation to the left to read about the available resources.
 
 ## Resource "Triggers"
 
-The time resources, except `time_rotating`, save base timestamps only when they are created; the results produced are stored in the Terraform state and re-used until the inputs change, prompting the resource to be recreated.
+Certain time resources, only perform actions during specific lifecycle actions:
 
-The resources all provide a map argument called `triggers` that can be populated with arbitrary key/value pairs that should be selected such that they remain the same until new time values are desired.
+- `time_offset`: Saves base timestamp into Terraform state only when created.
+- `time_sleep`: Sleeps when created and/or destroyed.
+- `time_static`: Saves base timestamp into Terraform state only when created.
+
+These resources provide an optional map argument called `triggers` that can be populated with arbitrary key/value pairs. When the keys or values of this argument are updated, Terraform will re-perform the desired action, such as updating the base timestamp or sleeping again.
 
 For example:
 
@@ -40,8 +44,6 @@ resource "aws_instance" "server" {
 }
 ```
 
-Resource "triggers" are optional. The other arguments to each resource must *also* remain constant in order to retain the same time result.
-
 `triggers` are *not* treated as sensitive attributes; a value used for `triggers` will be displayed in Terraform UI output as plaintext.
 
-To force a base timestamp to be replaced, the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html) can be used to produce a new time on the next run.
+To force a these actions to reoccur without updating `triggers`, the [`terraform taint` command](https://www.terraform.io/docs/commands/taint.html) can be used to produce the action on the next run.

--- a/website/docs/r/sleep.html.markdown
+++ b/website/docs/r/sleep.html.markdown
@@ -13,7 +13,7 @@ Manages a resource that delays creation and/or destruction, typically for furthe
 
 ## Example Usage
 
-### Creation Delay Usage
+### Delay Create Usage
 
 ```hcl
 # This resource will destroy (potentially immediately) after null_resource.next
@@ -22,7 +22,7 @@ resource "null_resource" "previous" {}
 resource "time_sleep" "wait_30_seconds" {
   depends_on = [null_resource.previous]
 
-  create_seconds = 30
+  create_duration = "30s"
 }
 
 # This resource will create (at least) 30 seconds after null_resource.previous
@@ -31,7 +31,7 @@ resource "null_resource" "next" {
 }
 ```
 
-### Destruction Delay Usage
+### Delay Destroy Usage
 
 ```hcl
 # This resource will destroy (at least) 30 seconds after null_resource.next
@@ -40,7 +40,7 @@ resource "null_resource" "previous" {}
 resource "time_sleep" "wait_30_seconds" {
   depends_on = [null_resource.previous]
 
-  destroy_seconds = 30
+  destroy_duration = "30s"
 }
 
 # This resource will create (potentially immediately) after null_resource.previous
@@ -60,7 +60,7 @@ resource "aws_ram_resource_association" "example" {
 # AWS resources shared via Resource Access Manager can take a few seconds to
 # propagate across AWS accounts after RAM returns a successful association.
 resource "time_sleep" "ram_resource_propagation" {
-  create_seconds = 60
+  create_duration = "60s"
 
   triggers = {
     # This sets up a proper dependency on the RAM association
@@ -82,8 +82,8 @@ resource "aws_db_subnet_group" "example" {
 
 The following arguments are optional:
 
-* `create_seconds` - (Optional) Number of seconds to sleep on resource creation. Updating this value by itself will not trigger sleeping.
-* `destroy_seconds` - (Optional) Number of seconds to sleep on resource destroy. Updating this value by itself will not trigger sleeping. This value or any updates to it must be successfully applied into the Terraform state before destroying this resource to take effect.
+* `create_duration` - (Optional) [Time duration][1] to delay resource creation. For example, `30s` for 30 seconds or `5m` for 5 minutes. Updating this value by itself will not trigger a delay.
+* `destroy_duration` - (Optional) [Time duration][1] to delay resource destroy. For example, `30s` for 30 seconds or `5m` for 5 minutes. Updating this value by itself will not trigger a delay. This value or any updates to it must be successfully applied into the Terraform state before destroying this resource to take effect.
 * `triggers` - (Optional) Arbitrary map of values that, when changed, will run any creation or destroy delays again. See [the main provider documentation](../index.html) for more information.
 
 ## Attributes Reference
@@ -94,10 +94,20 @@ In addition to all arguments above, the following attributes are exported:
 
 ## Import
 
-This resource can be imported with the `create_seconds` and `destroy_seconds`, separated by a comma (`,`), e.g.
+This resource can be imported with the `create_duration` and `destroy_duration`, separated by a comma (`,`).
+
+e.g. For 30 seconds create duration with no destroy duration:
 
 ```console
-$ terraform import time_sleep.example 30,0
+$ terraform import time_sleep.example 30s,
+```
+
+e.g. For 30 seconds destroy duration with no create duration:
+
+```console
+$ terraform import time_sleep.example ,30s
 ```
 
 The `triggers` argument cannot be imported.
+
+[1]: https://golang.org/pkg/time/#ParseDuration

--- a/website/docs/r/sleep.html.markdown
+++ b/website/docs/r/sleep.html.markdown
@@ -1,0 +1,103 @@
+---
+layout: "time"
+page_title: "Time: time_sleep"
+description: |-
+  Manages a static time resource.
+---
+
+# Resource: time_sleep
+
+Manages a resource that delays creation and/or destruction, typically for further resources. This prevents cross-platform compatibility and destroy-time issues with using the [`local-exec` provisioner](https://www.terraform.io/docs/provisioners/local-exec.html).
+
+-> In many cases, this resource should be considered a workaround for issues that should be reported and handled in downstream Terraform Provider logic. Downstream resources can usually introduce or adjust retries in their code to handle time delay issues for all Terraform configurations.
+
+## Example Usage
+
+### Creation Delay Usage
+
+```hcl
+# This resource will destroy (potentially immediately) after null_resource.next
+resource "null_resource" "previous" {}
+
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [null_resource.previous]
+
+  create_seconds = 30
+}
+
+# This resource will create (at least) 30 seconds after null_resource.previous
+resource "null_resource" "next" {
+  depends_on = [time_sleep.wait_30_seconds]
+}
+```
+
+### Destruction Delay Usage
+
+```hcl
+# This resource will destroy (at least) 30 seconds after null_resource.next
+resource "null_resource" "previous" {}
+
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [null_resource.previous]
+
+  destroy_seconds = 30
+}
+
+# This resource will create (potentially immediately) after null_resource.previous
+resource "null_resource" "next" {
+  depends_on = [time_sleep.wait_30_seconds]
+}
+```
+
+### Triggers Usage
+
+```hcl
+resource "aws_ram_resource_association" "example" {
+  resource_arn       = aws_subnet.example.arn
+  resource_share_arn = aws_ram_resource_share.example.arn
+}
+
+# AWS resources shared via Resource Access Manager can take a few seconds to
+# propagate across AWS accounts after RAM returns a successful association.
+resource "time_sleep" "ram_resource_propagation" {
+  create_seconds = 60
+
+  triggers = {
+    # This sets up a proper dependency on the RAM association
+    subnet_arn = aws_ram_resource_association.example.resource_arn
+    subnet_id  = aws_subnet.example.id
+  }
+}
+
+resource "aws_db_subnet_group" "example" {
+  name = "example"
+
+  # Read the Subnet identifier "through" the time_sleep resource to ensure a
+  # proper dependency and that both will change together.
+  subnet_ids = [time_sleep.ram_resource_propagation.triggers["subnet_id"]]
+}
+```
+
+## Argument Reference
+
+The following arguments are optional:
+
+* `create_seconds` - (Optional) Number of seconds to sleep on resource creation. Updating this value by itself will not trigger sleeping.
+* `destroy_seconds` - (Optional) Number of seconds to sleep on resource destroy. Updating this value by itself will not trigger sleeping. This value or any updates to it must be successfully applied into the Terraform state before destroying this resource to take effect.
+* `triggers` - (Optional) Arbitrary map of values that, when changed, will run any creation or destroy delays again. See [the main provider documentation](../index.html) for more information.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `id` - UTC RFC3339 timestamp of the creation or import, e.g. `2020-02-12T06:36:13Z`.
+
+## Import
+
+This resource can be imported with the `create_seconds` and `destroy_seconds`, separated by a comma (`,`), e.g.
+
+```console
+$ terraform import time_sleep.example 30,0
+```
+
+The `triggers` argument cannot be imported.

--- a/website/time.erb
+++ b/website/time.erb
@@ -19,6 +19,9 @@
                             <a href="/docs/providers/time/r/rotating.html">time_rotating</a>
                         </li>
                         <li>
+                            <a href="/docs/providers/time/r/sleep.html">time_sleep</a>
+                        </li>
+                        <li>
                             <a href="/docs/providers/time/r/static.html">time_static</a>
                         </li>
                     </ul>


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->

Introduces a bespoke new resource meant to replace other time delay solutions, such as using the `null_resource` resource with a `local-exec` provisioner:

```
resource "null_resource" "previous" {}

resource "null_resource" "wait_10_seconds" {
  provisioner "local-exec" {
    command = "sleep 10"
  }
  triggers = {
    previous = null_resource.previous.id
  }
}

resource "null_resource" "next" {
  depends_on = ["null_resource.wait_10_seconds"]
}
```

Having a first class resource clarifies configuration intents, creates a cross-platform compatible solution, and eliminates potential destroy-time provisioner reference issues. The resource itself is quite simple, accepting seconds to sleep for either creation and/or destroy.
