### PR TITLE
.github: Update issue templates to include chooser and separate bug report/feature request forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Something is incorrect or not working as expected.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report! Please note that this issue tracker is only used for bug reports and feature requests. Other issues will be closed.
+
+        If you have a configuration, workflow, or other question, please go back to the issue chooser and select one of the question links.
+  - type: textarea
+    id: versions
+    attributes:
+      label: Terraform CLI and Provider Versions
+      description: What versions of Terraform CLI and the provider?
+      placeholder: Output of `terraform version` from configuration directory
+    validations:
+      required: true
+  - type: textarea
+    id: terraform-configuration
+    attributes:
+      label: Terraform Configuration
+      description: Please copy and paste any relevant Terraform configuration. This will be automatically formatted into code, so no need for backticks.
+      render: terraform
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Description of what should have happened.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+      placeholder: Description of what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to Reproduce
+      description: List of steps to reproduce the issue.
+      value: |
+        1. `terraform apply`
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: How much impact is this issue causing?
+      description: High represents completely not able to use the provider or unexpected destruction of data/infrastructure. Medium represents unable to upgrade provider version or an issue with potential workaround. Low represents minor provider code, configuration, or documentation issues.
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: input
+    id: logs
+    attributes:
+      label: Logs
+      description: Please provide a link to a [GitHub Gist](https://gist.github.com) containing TRACE log output. [Terraform Debugging Documentation](https://www.terraform.io/internals/debugging)
+      placeholder: https://gist.github.com/example/12345678
+    validations:
+      required: false
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Are there any additional details about your environment, workflow, or recent changes that might be relevant? Have you discovered a workaround? Are there links to other related issues?
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Community Guidelines](https://www.hashicorp.com/community-guidelines).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/Feature_Request.yml
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Something is missing or could be improved.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this feature request! Please note that this issue tracker is only used for bug reports and feature requests. Other issues will be closed.
+
+        If you have a configuration, workflow, or other question, please go back to the issue chooser and select one of the question links.
+  - type: textarea
+    id: versions
+    attributes:
+      label: Terraform CLI and Provider Versions
+      description: What versions of Terraform CLI and the provider?
+      placeholder: Output of `terraform version` from configuration directory
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Cases or Problem Statement
+      description: What use cases or problems are you trying to solve?
+      placeholder: Description of use cases or problems.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What solutions would you prefer?
+      placeholder: Description of proposed solutions.
+    validations:
+      required: true
+  - type: dropdown
+    id: impact
+    attributes:
+      label: How much impact is this issue causing?
+      description: High represents completely not able to use the provider without this. Medium represents unable to solve a specific problem or understand something. Low represents minor provider code, configuration, or documentation issues.
+      options:
+        - High
+        - Medium
+        - Low
+    validations:
+      required: true
+  - type: textarea
+    id: additional-information
+    attributes:
+      label: Additional Information
+      description: Are there any additional details about your environment, workflow, or recent changes that might be relevant? Have you discovered a workaround? Are there links to other related issues?
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Community Guidelines](https://www.hashicorp.com/community-guidelines).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,8 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Terraform Time Provider Questions
-    url: https://discuss.hashicorp.com/c/terraform-providers/
-    about: GitHub issues in this repository are only intended for bug reports and feature requests. Other issues will be closed. Please ask and answer questions through the Terraform Provider Community Forum.
-  - name: Terraform Core Bug Reports and Feature Requests
-    url: https://github.com/hashicorp/terraform/issues/new/choose
-    about: Terraform Core, which handles the Terraform configuration language, CLI commands, and resource dependency graph, has its own codebase. Bug reports and feature requests for those pieces of functionality should be directed to that repository.
+  - name: Terraform Provider Questions
+    url: https://discuss.hashicorp.com/c/terraform-providers/31
+    about: GitHub issues in this repository are only intended for bug reports and feature requests. Other issues will be closed. Please ask and answer questions through the Terraform Provider section of HashiCorp Discuss.
   - name: Terraform Language or Workflow Questions
     url: https://discuss.hashicorp.com/c/terraform-core
-    about: Please ask and answer language or workflow related questions through the Terraform Core Community Forum.
-  - name: Security Vulnerability
-    url: https://www.hashicorp.com/security.html
-    about: Please report security vulnerabilities responsibly.
+    about: Please ask and answer language or workflow related questions through the Terraform Core section of HashiCorp Discuss.


### PR DESCRIPTION
Copied from terraform-provider-external. A link to HashiCorp's security policy and contact information will automatically be added by the GitHub organization configuration.