### PR TITLE
Fix link to time documentation in the terraform registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ terraform {
 
 ## Documentation, questions and discussions
 Official documentation on how to use this provider can be found on the
-[Terraform Registry](https://registry.terraform.io/providers/hashicorp/tls/latest/docs).
+[Terraform Registry](https://registry.terraform.io/providers/hashicorp/time/latest/docs).
 In case of specific questions or discussions, please use the
 HashiCorp [Terraform Providers Discuss forums](https://discuss.hashicorp.com/c/terraform-providers/31),
 in accordance with HashiCorp [Community Guidelines](https://www.hashicorp.com/community-guidelines).


### PR DESCRIPTION
This is a tiny patch fixing a link in the README. I presume the link to the TLS documentation instead of the Time documentation was a copy-paste mistake from when the file was initially added.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
