### PR TITLE
Fix misleading docs for time_offset.id

### DIFF
--- a/docs/resources/offset.md
+++ b/docs/resources/offset.md
@@ -68,7 +68,7 @@ resource "aws_instance" "server" {
 
 - `day` (Number) Number day of offset timestamp.
 - `hour` (Number) Number hour of offset timestamp.
-- `id` (String) RFC3339 format of the offset timestamp, e.g. `2020-02-12T06:36:13Z`.
+- `id` (String) RFC3339 format of the timestamp, e.g. `2020-02-12T06:36:13Z`.
 - `minute` (Number) Number minute of offset timestamp.
 - `month` (Number) Number month of offset timestamp.
 - `rfc3339` (String) RFC3339 format of the offset timestamp, e.g. `2020-02-12T06:36:13Z`.

--- a/internal/provider/resource_time_offset.go
+++ b/internal/provider/resource_time_offset.go
@@ -114,7 +114,7 @@ func (t timeOffsetResource) Schema(ctx context.Context, req resource.SchemaReque
 				Computed:    true,
 			},
 			"id": schema.StringAttribute{
-				Description: "RFC3339 format of the offset timestamp, e.g. `2020-02-12T06:36:13Z`.",
+				Description: "RFC3339 format of the timestamp, e.g. `2020-02-12T06:36:13Z`.",
 				Computed:    true,
 			},
 		},


### PR DESCRIPTION
Currently the id of time_offset resource is set to formattedTimestamp, not formattedOffsetTimestamp,
however the documentation suggests otherwise.

This updates the docs to match the implementation.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates #137
