### PR TITLE
ci: merging `golangci-lint` rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,21 +1,26 @@
-linters:
-  # Default linters enabled
-  # See: https://golangci-lint.run/usage/linters/#enabled-by-default-linters
 
-  # Additional linters enabled
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
   enable:
     - durationcheck
+    - errcheck
     - exportloopref
+    - forcetypeassert
     - godot
     - gofmt
+    - gosimple
+    - ineffassign
     - makezero
     - misspell
     - nilerr
     - predeclared
+    - staticcheck
     - tenv
     - unconvert
     - unparam
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
+    - unused
+    - vet


### PR DESCRIPTION
contributes to:
- https://github.com/hashicorp/terraform-providers-devex-internal/issues/102

### Notes
- Skipping `paralleltest` for the providers
