### PR TITLE
docs: fix time_rotating import examples

### DIFF
--- a/docs/resources/rotating.md
+++ b/docs/resources/rotating.md
@@ -51,13 +51,13 @@ resource "time_rotating" "example" {
 This resource can be imported using the base UTC RFC3339 value and rotation years, months, days, hours, and minutes, separated by commas (`,`), e.g. for 30 days
 
 ```shell
-terraform import time_rotation.example 2020-02-12T06:36:13Z,0,0,30,0,0
+terraform import time_rotating.example 2020-02-12T06:36:13Z,0,0,30,0,0
 ```
 
 Otherwise, to import with the rotation RFC3339 value, the base UTC RFC3339 value and rotation UTC RFC3339 value, separated by commas (`,`), e.g.
 
 ```shell
-terraform import time_rotation.example 2020-02-12T06:36:13Z,2020-02-13T06:36:13Z
+terraform import time_rotating.example 2020-02-12T06:36:13Z,2020-02-13T06:36:13Z
 ```
 
 The `triggers` argument cannot be imported.

--- a/examples/resources/time_rotating/import_base_value.sh
+++ b/examples/resources/time_rotating/import_base_value.sh
@@ -1,1 +1,1 @@
-terraform import time_rotation.example 2020-02-12T06:36:13Z,0,0,30,0,0
+terraform import time_rotating.example 2020-02-12T06:36:13Z,0,0,30,0,0

--- a/examples/resources/time_rotating/import_rotation_value.sh
+++ b/examples/resources/time_rotating/import_rotation_value.sh
@@ -1,1 +1,1 @@
-terraform import time_rotation.example 2020-02-12T06:36:13Z,2020-02-13T06:36:13Z
+terraform import time_rotating.example 2020-02-12T06:36:13Z,2020-02-13T06:36:13Z


### PR DESCRIPTION
This fixes the current import examples which uses incorrect resource names.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
