### PR TITLE
fix: issue-labeler - add required input

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml
-        enable-versioned-regex: 1
+        enable-versioned-regex: 0

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -13,3 +13,4 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         configuration-path: .github/labeler-issue-triage.yml
+        enable-versioned-regex: 1


### PR DESCRIPTION
While opening a new issue, noticed that there are [broken actions](https://github.com/hashicorp/terraform-provider-time/actions/runs/5016807191).

> Run github/issue-labeler@e24a3eb6b2e28c8904d086302a2b760647f5f45c
> Error: Error: Input required and not supplied: enable-versioned-regex

It appears be to due to a breaking change for [issue-labeler v3.0](https://github.com/github/issue-labeler/releases/tag/v3.0) due to [an automatic deps bump](https://github.com/hashicorp/terraform-provider-time/pull/166).

> Breaking change: Issue labels that do not match a regex will no longer be removed by default unless you set sync-labels: to 1

Since `will no longer be removed by default` implies it was being removed by default, `enable-versioned-regex` is being set to `1` in this PR.

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
