### PR TITLE
Add changelogs for `v0.9.2` release

### DIFF
--- a/.changes/unreleased/NOTES-20230303-162903.yaml
+++ b/.changes/unreleased/NOTES-20230303-162903.yaml
@@ -1,6 +1,0 @@
-kind: NOTES
-body: This Go module has been updated to Go 1.19 per the [Go support policy](https://golang.org/doc/devel/release.html#policy).
-  Any consumers building on earlier Go versions may experience errors.
-time: 2023-03-03T16:29:03.866461Z
-custom:
-  Issue: "177"

--- a/.changes/unreleased/NOTES-20231127-093945.yaml
+++ b/.changes/unreleased/NOTES-20231127-093945.yaml
@@ -1,0 +1,6 @@
+kind: NOTES
+body: This release introduces no functional changes. It does however include dependency
+  updates which address upstream CVEs.
+time: 2023-11-27T09:39:45.916692-05:00
+custom:
+  Issue: "263"


### PR DESCRIPTION
Added a new changelog entry for the upcoming `v0.9.2` patch release and removed the Go upgrade changelog (since this isn't an external Go module)