### PR TITLE
.github/workflows: Update to hashicorp/ghaction-terraform-provider-release@v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
     permissions:
       contents: write # Needed for goreleaser to create GitHub release
       issues: write # Needed for goreleaser to close associated milestone
-    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@01981baad5d35ce2342924e60ae91cf69fe31fd0 # v2.3.0
+    uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/hashicorp.yml@9b5d2ca4b85f3a54d5c4d12e7690ddad1526ff6c # v3.0.1
     secrets:
       hc-releases-key-prod: '${{ secrets.HC_RELEASES_KEY_PROD }}'
       hc-releases-key-staging: '${{ secrets.HC_RELEASES_KEY_STAGING }}'


### PR DESCRIPTION
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v3.0.0
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/releases/tag/v3.0.1

The `actions/upload-artifact` action has already been upgraded to v4, so the `hashicorp/ghaction-terraform-provider-release` action must also be upgraded to prevent errors on release.

