### PR TITLE
docs: Fix YAML frontmatter in template

### DIFF
--- a/.changes/unreleased/NOTES-20240311-150600.yaml
+++ b/.changes/unreleased/NOTES-20240311-150600.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: No functional changes from v0.11.0. Fixed documentation YAML frontmatter.
+time: 2024-03-11T15:06:00.101166-04:00
+custom:
+  Issue: "299"

--- a/.changes/unreleased/NOTES-20240311-150600.yaml
+++ b/.changes/unreleased/NOTES-20240311-150600.yaml
@@ -1,5 +1,5 @@
 kind: NOTES
-body: No functional changes from v0.11.0. Fixed documentation YAML frontmatter.
+body: No functional changes from v0.11.0. Minor documentation fixes.
 time: 2024-03-11T15:06:00.101166-04:00
 custom:
   Issue: "299"

--- a/docs/functions/rfc3339_parse.md
+++ b/docs/functions/rfc3339_parse.md
@@ -1,3 +1,4 @@
+---
 page_title: "rfc3339_parse function - terraform-provider-time"
 subcategory: ""
 description: |-

--- a/templates/functions/rfc3339_parse.md.tmpl
+++ b/templates/functions/rfc3339_parse.md.tmpl
@@ -1,3 +1,4 @@
+---
 page_title: "{{.Name}} {{.Type}} - {{.ProviderName}}"
 subcategory: ""
 description: |-


### PR DESCRIPTION
Follow up to #280

I missed the beginning of the YAML frontmatter syntax 😞. Will be good to get the new docs `validate` command on this repository soon 🙂 