### PR TITLE
Added trigger imports into time_sleep

### DIFF
--- a/internal/provider/resource_time_sleep.go
+++ b/internal/provider/resource_time_sleep.go
@@ -92,10 +92,12 @@ func (t timeSleepResource) ImportState(ctx context.Context, req resource.ImportS
 
 	idParts := strings.Split(id, ",")
 
-	if len(idParts) != 2 || (idParts[0] == "" && idParts[1] == "") {
+	if len(idParts) < 2 || (idParts[0] == "" && idParts[1] == "") {
 		resp.Diagnostics.AddError(
 			"Unexpected Format of ID",
-			fmt.Sprintf("Unexpected format of ID (%q), expected CREATEDURATION,DESTROYDURATION where at least one value is non-empty", id))
+			fmt.Sprintf(
+				`Unexpected format of ID (%q), expected CREATEDURATION,DESTROYDURATION,KEY=VALUE,KEY=VALUE... ",
+				where at least one CREATIONDURATION or DESTROYDURATION value is non-empty`, id))
 
 		return
 	}
@@ -132,7 +134,23 @@ func (t timeSleepResource) ImportState(ctx context.Context, req resource.ImportS
 		state.DestroyDuration = types.StringValue(idParts[1])
 	}
 
-	state.Triggers = types.MapValueMust(types.StringType, map[string]attr.Value{})
+	triggers := map[string]attr.Value{}
+	// We have triggers defined so we need to parse and import.
+	if len(idParts) > 2 {
+		for _, trigger := range idParts[2:] {
+			value := strings.Split(trigger, "=")
+			if len(value) != 2 {
+				resp.Diagnostics.AddError("Trigger import error",
+					fmt.Sprintf("Trigger import entries must be KEY=VALUE, got %s", trigger),
+				)
+				return
+			}
+
+			triggers[value[0]] = types.StringValue(value[1])
+		}
+	}
+
+	state.Triggers = types.MapValueMust(types.StringType, triggers)
 
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)


### PR DESCRIPTION
Implemented importing triggers using an expanded syntax for the trigger map. The format of the trigger definition is as follows:

"CREATE,DESTROY,KEY=VALUE,KEY=VALUE..."

Without being able to import triggers, a time_sleep import will always cause a replacement and therefore may trigger replaces for resources that depend on the time_sleep when they are not needed. 

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000
