### PR TITLE
update go to 1.25.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-time
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
## Description
Updates the go standard library to addresses GO-2026-4337, but the provider should not be affected by this vulnerability. This will help appease security scanning tools (Ref: PSA-2663).
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes