### PR TITLE
resource/time_offset: correct id attribute documentation

### DIFF
--- a/.changes/unreleased/NOTES-20260724-120000.yaml
+++ b/.changes/unreleased/NOTES-20260724-120000.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: 'resource/time_offset: The `id` attribute documentation now correctly describes it as the base timestamp rather than the offset timestamp, matching its actual value'
+time: 2026-07-24T12:00:00.000000000Z
+custom:
+  Issue: "416"

--- a/docs/resources/offset.md
+++ b/docs/resources/offset.md
@@ -81,7 +81,7 @@ resource "aws_instance" "server" {
 
 - `day` (Number) Number day of offset timestamp.
 - `hour` (Number) Number hour of offset timestamp.
-- `id` (String) RFC3339 format of the offset timestamp, e.g. `2020-02-12T06:36:13Z`.
+- `id` (String) RFC3339 format of the base timestamp, e.g. `2020-02-12T06:36:13Z`.
 - `minute` (Number) Number minute of offset timestamp.
 - `month` (Number) Number month of offset timestamp.
 - `rfc3339` (String) RFC3339 format of the offset timestamp, e.g. `2020-02-12T06:36:13Z`.

--- a/internal/provider/resource_time_offset.go
+++ b/internal/provider/resource_time_offset.go
@@ -147,7 +147,7 @@ func (t *timeOffsetResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"id": schema.StringAttribute{
 				CustomType:  timetypes.RFC3339Type{},
-				Description: "RFC3339 format of the offset timestamp, e.g. `2020-02-12T06:36:13Z`.",
+				Description: "RFC3339 format of the base timestamp, e.g. `2020-02-12T06:36:13Z`.",
 				Computed:    true,
 			},
 		},


### PR DESCRIPTION
## Related Issue

Fixes #416

## Description

The `time_offset` resource sets its `id` attribute to the **base** timestamp:

```go
plan.BaseRFC3339 = timetypes.NewRFC3339TimeValue(timestamp)
...
plan.RFC3339 = timetypes.NewRFC3339TimeValue(offsetTimestamp)
plan.ID = timetypes.NewRFC3339TimeValue(timestamp)
```

So `id` always equals `base_rfc3339`, while the offset timestamp is exposed via `rfc3339`. However, the `id` attribute's schema description read *"RFC3339 format of the offset timestamp"*, which the reporter (and generated docs) reasonably read as a guarantee that `id` holds the offset time. It does not.

This is a documentation-only fix: the description now reads *"RFC3339 format of the base timestamp"*, matching the resource's actual behavior. I intentionally did **not** change what `id` stores — `id` is the resource identity (used for import as `BASETIMESTAMP,YEARS,...`), so altering its value would be a breaking change, and the reporter explicitly notes that correcting the documentation is the appropriate fix.

Changes:
- Updated the `id` attribute `Description` in `internal/provider/resource_time_offset.go`.
- Hand-synced the tfplugindocs-generated `docs/resources/offset.md` to match (no toolchain available to run `make generate`).
- Added a Changie `NOTES` fragment.

Scoped to `time_offset` since that is where base and offset are distinct values and where the issue was filed.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No. This is a documentation-only change with no effect on access controls, encryption, or logging.