### PR TITLE
update Go version to 1.26.8

### DIFF
--- a/.changes/unreleased/NOTES-20260909-121025.yaml
+++ b/.changes/unreleased/NOTES-20260909-121025.yaml
@@ -1,0 +1,5 @@
+kind: NOTES
+body: Upgrade the Go toolchain to 1.26.8.
+time: 2026-09-09T12:10:25.86579+02:00
+custom:
+    Issue: "511"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Please note: Issues on this repository are intended to be related to bugs or fea
 ## Requirements
 
 * [Terraform](https://www.terraform.io/downloads)
-* [Go](https://go.dev/doc/install) (1.24)
+* [Go](https://go.dev/doc/install) (1.26)
 * [GNU Make](https://www.gnu.org/software/make/)
 * [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) (optional)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/terraform-provider-time
 
-go 1.25.8
+go 1.26.8
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.25.8
+go 1.26.8
 
 require (
 	github.com/hashicorp/copywrite v0.25.2


### PR DESCRIPTION
## Summary

- Update the provider and tools modules to Go 1.26.8.
- Update the documented local Go requirement to Go 1.26.

## Validation

- `make generate`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `make testacc`

All validation passed locally with Go 1.26.8.

Assisted-by: OpenCode